### PR TITLE
Read site URL from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Supabase
 VITE_SUPABASE_URL=your-supabase-url
 VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
+# Base URL for SEO component
+VITE_SITE_URL=https://example.com
 
 # Storage Configuration
 STORAGE_TYPE=netlify # or supabase

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # travel
 
 [Edit in StackBlitz next generation editor ⚡️](https://stackblitz.com/~/github.com/jusaprint/travel)
+
+## Environment Variables
+
+The application reads the site URL from `VITE_SITE_URL`. Define this in your `.env` file to customize the canonical links and Open Graph metadata. Example:
+
+```bash
+VITE_SITE_URL=https://example.com
+```
+

--- a/src/components/SEO.jsx
+++ b/src/components/SEO.jsx
@@ -18,7 +18,7 @@ export default function SEO({
 
   const siteTitle = settings?.site?.title || 'KudoSIM';
   const siteDescription = settings?.site?.tagline || 'Global Connectivity for Modern Travelers';
-  const siteUrl = 'https://kudosim.com'; // Replace with your actual domain
+  const siteUrl = import.meta.env.VITE_SITE_URL || 'https://kudosim.com';
 
   const seo = {
     title: title ? `${title} | ${siteTitle}` : siteTitle,


### PR DESCRIPTION
## Summary
- support VITE_SITE_URL for canonical links in SEO component
- document `VITE_SITE_URL` usage
- add example variable to `.env.example`

## Testing
- `npm run build` *(fails: vite not found)*