### PR TITLE
Add translation keys and localize country page

### DIFF
--- a/src/i18n/locales/de/country.json
+++ b/src/i18n/locales/de/country.json
@@ -19,5 +19,9 @@
   "valid.for": "Gültig für",
   "days": "Tage",
   "most.popular": "Am Beliebtesten",
-  "best.value": "Bestes Angebot"
+  "best.value": "Bestes Angebot",
+  "phone": "Telefon",
+  "calling.texting": "Anrufe & SMS",
+  "speed.value": "LTE/5G",
+  "select.package": "Wähle Dein Datenpaket"
 }

--- a/src/i18n/locales/en/country.json
+++ b/src/i18n/locales/en/country.json
@@ -19,5 +19,9 @@
   "valid.for": "Valid for",
   "days": "days",
   "most.popular": "Most Popular",
-  "best.value": "Best Value"
+  "best.value": "Best Value",
+  "phone": "Phone",
+  "calling.texting": "Calling & Texting",
+  "speed.value": "LTE/5G",
+  "select.package": "Select Your Data Package"
 }

--- a/src/i18n/locales/fr/country.json
+++ b/src/i18n/locales/fr/country.json
@@ -19,5 +19,9 @@
   "valid.for": "Valable pour",
   "days": "jours",
   "most.popular": "Plus Populaire",
-  "best.value": "Meilleur Rapport Qualité-Prix"
+  "best.value": "Meilleur Rapport Qualité-Prix",
+  "phone": "Téléphone",
+  "calling.texting": "Appels & SMS",
+  "speed.value": "LTE/5G",
+  "select.package": "Sélectionnez Votre Forfait Data"
 }

--- a/src/i18n/locales/sq/country.json
+++ b/src/i18n/locales/sq/country.json
@@ -19,5 +19,9 @@
   "valid.for": "E vlefshme për",
   "days": "ditë",
   "most.popular": "Më i Popullarizuar",
-  "best.value": "Vlera më e Mirë"
+  "best.value": "Vlera më e Mirë",
+  "phone": "Telefoni",
+  "calling.texting": "Thirrje & Mesazhe",
+  "speed.value": "LTE/5G",
+  "select.package": "Zgjidh Paketën e të Dhënave"
 }

--- a/src/i18n/locales/tr/country.json
+++ b/src/i18n/locales/tr/country.json
@@ -19,5 +19,9 @@
   "valid.for": "Geçerlilik süresi",
   "days": "gün",
   "most.popular": "En Popüler",
-  "best.value": "En İyi Değer"
+  "best.value": "En İyi Değer",
+  "phone": "Telefon",
+  "calling.texting": "Arama & Mesajlaşma",
+  "speed.value": "LTE/5G",
+  "select.package": "Veri Paketinizi Seçin"
 }

--- a/src/pages/CountryPage.jsx
+++ b/src/pages/CountryPage.jsx
@@ -167,19 +167,7 @@ export default function CountryPage() {
   // Get multilingual subtitle text
   const getSubtitleText = () => {
     const countryName = getTranslatedCountryName();
-    
-    switch(i18n.language) {
-      case 'sq':
-        return `Downloadable ${countryName} SIM card with prepaid data`;
-      case 'fr':
-        return `Carte SIM téléchargeable ${countryName} avec données prépayées`;
-      case 'de':
-        return `Herunterladbare ${countryName} SIM-Karte mit vorausbezahlten Daten`;
-      case 'tr':
-        return `Ön ödemeli veriye sahip indirilebilir ${countryName} SIM kartı`;
-      default: // English and fallback
-        return `Downloadable ${countryName} SIM card with prepaid data`;
-    }
+    return t('downloadable.sim', { country: countryName });
   };
 
   // Handle package selection
@@ -437,7 +425,7 @@ export default function CountryPage() {
                     </svg>
                   </div>
                   <div>
-                    <p className="text-sm text-gray-500">Network</p>
+                    <p className="text-sm text-gray-500">{t('network')}</p>
                     <p className="font-medium text-gray-900">Vodafone</p>
                   </div>
                 </div>
@@ -451,8 +439,8 @@ export default function CountryPage() {
                     </svg>
                   </div>
                   <div>
-                    <p className="text-sm text-gray-500">Phone</p>
-                    <p className="font-medium text-gray-900">Calling & Texting</p>
+                    <p className="text-sm text-gray-500">{t('phone')}</p>
+                    <p className="font-medium text-gray-900">{t('calling.texting')}</p>
                   </div>
                 </div>
               </div>
@@ -465,15 +453,15 @@ export default function CountryPage() {
                     </svg>
                   </div>
                   <div>
-                    <p className="text-sm text-gray-500">Speed</p>
-                    <p className="font-medium text-gray-900">LTE/5G</p>
+                    <p className="text-sm text-gray-500">{t('speed')}</p>
+                    <p className="font-medium text-gray-900">{t('speed.value')}</p>
                   </div>
                 </div>
               </div>
             </div>
 
             {/* Packages grid - Updated to 4-per-row on desktop */}
-            <h2 className="text-xl font-bold text-gray-900 mb-4">Select Your Data Package</h2>
+            <h2 className="text-xl font-bold text-gray-900 mb-4">{t('select.package')}</h2>
             <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-24">
               {packages.map((pkg) => (
                 <PackageCard


### PR DESCRIPTION
## Summary
- localize CountryPage text
- add phone, calling, speed value, and package selection strings to i18n locales

## Testing
- `npm run build` *(fails: vite not found)*