### PR TITLE
Implement ScrollToTop for footer navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import { TranslationProvider } from './context/TranslationContext';
 import { MotionConfigProvider } from './components/motion-config';
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
+import ScrollToTop from './components/ScrollToTop';
 import HomePage from './pages/HomePage';
 import Destinations from './pages/Destinations';
 import CountryPage from './pages/CountryPage';
@@ -30,6 +31,7 @@ import AdminRoutes from './admin/AdminRoutes';
 function App() {
   return (
     <BrowserRouter>
+      <ScrollToTop />
       <HelmetProvider>
         <SettingsProvider>
           <LanguageProvider>

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Scrolls the window to the top whenever the route changes.
+ * This ensures new pages start at the top even when navigated
+ * from the footer or other in-page links.
+ */
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add `ScrollToTop` component that resets window scroll position
- integrate `ScrollToTop` in `App` so pages open from the top

## Testing
- `git status --short`