### PR TITLE
Add translations for data package text

### DIFF
--- a/src/i18n/locales/de/country.json
+++ b/src/i18n/locales/de/country.json
@@ -10,6 +10,7 @@
   "hotspot": "Hotspot",
   "hotspot.allowed": "Kudo Hotspot ist erlaubt",
   "speed": "Geschwindigkeit",
+  "select.data.package": "Wählen Sie Ihr Datenpaket",
   "available.packages": "Verfügbare Pakete",
   "features": "Funktionen",
   "description": "Beschreibung",

--- a/src/i18n/locales/en/country.json
+++ b/src/i18n/locales/en/country.json
@@ -10,6 +10,7 @@
   "hotspot": "Hotspot",
   "hotspot.allowed": "Kudo hotspot is allowed",
   "speed": "Speed",
+  "select.data.package": "Select Your Data Package",
   "available.packages": "Available Packages",
   "features": "Features",
   "description": "Description",

--- a/src/i18n/locales/fr/country.json
+++ b/src/i18n/locales/fr/country.json
@@ -10,6 +10,7 @@
   "hotspot": "Point d'accès",
   "hotspot.allowed": "Le point d'accès Kudo est autorisé",
   "speed": "Vitesse",
+  "select.data.package": "Sélectionnez votre forfait de données",
   "available.packages": "Forfaits Disponibles",
   "features": "Caractéristiques",
   "description": "Description",

--- a/src/i18n/locales/sq/country.json
+++ b/src/i18n/locales/sq/country.json
@@ -10,6 +10,7 @@
   "hotspot": "Hotspot",
   "hotspot.allowed": "Kudo hotspot është i lejuar",
   "speed": "Shpejtësia",
+  "select.data.package": "Zgjidhni Paketën Tuaj të të Dhënave",
   "available.packages": "Paketat e Disponueshme",
   "features": "Veçoritë",
   "description": "Përshkrimi",

--- a/src/i18n/locales/tr/country.json
+++ b/src/i18n/locales/tr/country.json
@@ -10,6 +10,7 @@
   "hotspot": "Hotspot",
   "hotspot.allowed": "Kudo hotspot kullanımına izin verilir",
   "speed": "Hız",
+  "select.data.package": "Veri Paketini Seçin",
   "available.packages": "Mevcut Paketler",
   "features": "Özellikler",
   "description": "Açıklama",

--- a/src/pages/CountryPage.jsx
+++ b/src/pages/CountryPage.jsx
@@ -68,7 +68,7 @@ const PackageCard = ({ pkg, badge, t, isSelected, onSelect }) => (
           {pkg.name.match(/\d+/)?.[0] || '0'}GB
         </h3>
         <div className="text-sm text-gray-500 mb-4">
-          Valid for {pkg.validity_days} days
+          {t('valid.for', 'Valid for')} {pkg.validity_days} {t('days', 'days')}
         </div>
       </div>
 
@@ -473,7 +473,9 @@ export default function CountryPage() {
             </div>
 
             {/* Packages grid - Updated to 4-per-row on desktop */}
-            <h2 className="text-xl font-bold text-gray-900 mb-4">Select Your Data Package</h2>
+            <h2 className="text-xl font-bold text-gray-900 mb-4">
+              {t('select.data.package', 'Select Your Data Package')}
+            </h2>
             <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-24">
               {packages.map((pkg) => (
                 <PackageCard


### PR DESCRIPTION
## Summary
- localize "Select Your Data Package" header
- translate validity text in package cards
- provide new translations for each language

## Testing
- `npm ci` *(fails: Exit handler never called)*
- `npm run build` *(fails: vite not found)*