### PR TITLE
Implement ScrollToTop for footer navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import { TranslationProvider } from './context/TranslationContext';
 import { MotionConfigProvider } from './components/motion-config';
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
+import ScrollToTop from './components/ScrollToTop';
 import HomePage from './pages/HomePage';
 import Destinations from './pages/Destinations';
 import CountryPage from './pages/CountryPage';
@@ -30,6 +31,7 @@ import AdminRoutes from './admin/AdminRoutes';
 function App() {
   return (
     <BrowserRouter>
+      <ScrollToTop />
       <HelmetProvider>
         <SettingsProvider>
           <LanguageProvider>

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,17 @@
+import { useLayoutEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Scrolls the window to the top whenever the route changes.
+ * This ensures new pages start at the top even when navigated
+ * from the footer or other in-page links.
+ */
+export default function ScrollToTop() {
+  const { pathname, search, hash } = useLocation();
+
+  useLayoutEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+  }, [pathname, search, hash]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add `ScrollToTop` component that resets window scroll position
- integrate `ScrollToTop` in `App` so pages open from the top
- switch to `useLayoutEffect` and watch full location to ensure every navigation resets scroll

## Testing
- `npm test` *(fails: Missing script)*
- `git status --short`