### PR TITLE
Update mobile header icons

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -383,29 +383,46 @@ export default function Navbar() {
             <LanguageSwitcher />
           </div>
 
-          {/* CTA Button */}
+          {/* CTA Button Desktop */}
           <Link
             to="#"
-            className="inline-flex items-center gap-2 text-white font-medium px-4 sm:px-6 py-2 sm:py-2.5 rounded-full text-sm shadow-lg transition-all duration-300"
-            style={{ 
+            className="hidden md:inline-flex items-center gap-2 text-white font-medium px-4 sm:px-6 py-2 sm:py-2.5 rounded-full text-sm shadow-lg transition-all duration-300"
+            style={{
               backgroundColor: settings?.site?.primaryColor || '#690d89'
             }}
           >
             <span className="hidden sm:inline">
-              <TranslatedText 
-                textKey="Shop" 
-                namespace="common" 
+              <TranslatedText
+                textKey="Shop"
+                namespace="common"
                 fallback="Shop"
               />
             </span>{' '}
-            <TranslatedText 
-              textKey="Shop eSIMs" 
-              namespace="common" 
+            <TranslatedText
+              textKey="Shop eSIMs"
+              namespace="common"
               fallback="Shop eSIMs"
             />
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5l7 7m0 0l-7 7m7-7H3" />
             </svg>
+          </Link>
+
+          {/* CTA Button Mobile */}
+          <Link
+            to="#"
+            className="inline-flex md:hidden items-center gap-1 text-white font-medium px-3 py-2 rounded-full text-sm shadow-lg transition-all duration-300"
+            style={{
+              backgroundColor: settings?.site?.primaryColor || '#690d89'
+            }}
+          >
+            <svg className="w-4 h-4 text-white" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+            </svg>
+            <svg className="w-4 h-4 text-white" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M3,20.5V3.5C3,2.91 3.34,2.39 3.84,2.15L13.69,12L3.84,21.85C3.34,21.6 3,21.09 3,20.5M16.81,15.12L6.05,21.34L14.54,12.85L16.81,15.12M20.16,10.81C20.5,11.08 20.75,11.5 20.75,12C20.75,12.5 20.53,12.9 20.18,13.18L17.89,14.5L15.39,12L17.89,9.5L20.16,10.81M6.05,2.66L16.81,8.88L14.54,11.15L6.05,2.66Z" />
+            </svg>
+            <span>Download App</span>
           </Link>
 
           {/* Mobile Menu Button */}
@@ -556,14 +573,13 @@ export default function Navbar() {
                     className="flex items-center justify-center gap-2 w-full bg-[#690d89] text-white font-medium px-6 py-3 rounded-xl shadow-lg hover:bg-[#8B5CF6] transition-all duration-300"
                     onClick={() => setIsOpen(false)}
                   >
-                    <TranslatedText 
-                      textKey="Shop eSIMs" 
-                      namespace="common" 
-                      fallback="Shop eSIMs"
-                    />
-                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5l7 7m0 0l-7 7m7-7H3" />
+                    <svg className="w-5 h-5 text-white" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
                     </svg>
+                    <svg className="w-5 h-5 text-white" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M3,20.5V3.5C3,2.91 3.34,2.39 3.84,2.15L13.69,12L3.84,21.85C3.34,21.6 3,21.09 3,20.5M16.81,15.12L6.05,21.34L14.54,12.85L16.81,15.12M20.16,10.81C20.5,11.08 20.75,11.5 20.75,12C20.75,12.5 20.53,12.9 20.18,13.18L17.89,14.5L15.39,12L17.89,9.5L20.16,10.81M6.05,2.66L16.81,8.88L14.54,11.15L6.05,2.66Z" />
+                    </svg>
+                    <span>Download App</span>
                   </Link>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- ensure Apple and Android icons are white in the mobile header and menu buttons

## Testing
- `npm run build` *(fails: vite not found)*